### PR TITLE
MIGENG-141 Implemented separated rules for each flag

### DIFF
--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Flags.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Flags.drl
@@ -6,37 +6,34 @@ import java.util.HashSet;
 
 dialect "java"
 agenda-group "Flags"
-auto-focus true
+lock-on-active true
 
-rule "Flags"
+rule "Flag_Nics"
     when
         vmWorkloadInventoryModel : VMWorkloadInventoryModel(
             nicsCount != null,
-            hasRdmDisk != null
-            //vmDiskFilenames != null
+            nicsCount > 4
         )
         workloadInventoryReport : WorkloadInventoryReportModel()
     then
-        HashSet flags = new HashSet<>();
-
-        if (vmWorkloadInventoryModel.getNicsCount()>4)
-        {
-            flags.add(WorkloadInventoryReportModel.MORE_THAN_4_NICS_FLAG_NAME);
-        }
-        if (vmWorkloadInventoryModel.isHasRdmDisk())
-        {
-            flags.add(WorkloadInventoryReportModel.RDM_DISK_FLAG_NAME);
-        }
-
-        //TODO Add Shared Disk check to the rule here
-
         modify(workloadInventoryReport)
         {
-            setFlagsIMS(flags)
+            addFlagIMS(WorkloadInventoryReportModel.MORE_THAN_4_NICS_FLAG_NAME)
         }
-
-        kcontext.getKieRuntime().getAgenda().getAgendaGroup("Flags").setFocus();
-        kcontext.getKieRuntime().getAgenda().getAgendaGroup("Targets").setFocus();
-        kcontext.getKieRuntime().getAgenda().getAgendaGroup("Complexity").setFocus();
-        kcontext.getKieRuntime().getAgenda().getAgendaGroup("Workloads").setFocus();
 end
+
+rule "Flag_Rdm_Disk"
+    when
+        vmWorkloadInventoryModel : VMWorkloadInventoryModel(
+            hasRdmDisk != null,
+            hasRdmDisk == true
+        )
+        workloadInventoryReport : WorkloadInventoryReportModel()
+    then
+        modify(workloadInventoryReport)
+        {
+            addFlagIMS(WorkloadInventoryReportModel.RDM_DISK_FLAG_NAME)
+        }
+end
+
+//TODO Add Shared Disk check to the rule here

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 
@@ -29,7 +30,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
     @Test
     public void test() {
         // check that the numbers of rule from the DRL file is the number of rules loaded
-        Utils.checkLoadedRulesNumber(kieSession, "org.jboss.xavier.analytics.rules.workload.inventory", 3);
+        Utils.checkLoadedRulesNumber(kieSession, "org.jboss.xavier.analytics.rules.workload.inventory", 4);
 
         // create a Map with the facts (i.e. Objects) you want to put in the working memory
         Map<String, Object> facts = new HashMap<>();
@@ -65,13 +66,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(2, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(3, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
        Utils.verifyRulesFiredNames(this.agendaEventListener,
             // BasicFields
             "Copy basic fields and agenda controller",
             // Flags
-                "Flags"
+               "Flag_Nics", "Flag_Rdm_Disk"
             // Targets
             // Complexity
             // Workloads
@@ -100,9 +101,11 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("Red Hat Enterprise Linux Server release 7.6 (Maipo)",workloadInventoryReportModel.getOsDescription());
         Assert.assertEquals("RHEL",workloadInventoryReportModel.getOsName());
         // Flags
-        Assert.assertEquals(2,workloadInventoryReportModel.getFlagsIMS().size());
-        Assert.assertTrue(workloadInventoryReportModel.getFlagsIMS().contains(WorkloadInventoryReportModel.MORE_THAN_4_NICS_FLAG_NAME));
-        Assert.assertTrue(workloadInventoryReportModel.getFlagsIMS().contains(WorkloadInventoryReportModel.RDM_DISK_FLAG_NAME));
+        Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
+        Assert.assertNotNull(flagsIMS);
+        Assert.assertEquals(2, flagsIMS.size());
+        Assert.assertTrue(flagsIMS.contains(WorkloadInventoryReportModel.MORE_THAN_4_NICS_FLAG_NAME));
+        Assert.assertTrue(flagsIMS.contains(WorkloadInventoryReportModel.RDM_DISK_FLAG_NAME));
         // Targets
         // Complexity
         // Workloads


### PR DESCRIPTION
* removed `auto-focus true` because we have the set of `setFocus()` calls to give to each agenda group (after `BasicFields`) the focus to let it execute
* added `lock-on-active true` to avoid loops with the rules of the same agenda group since they work on the very same objects so they could trigger some infinite loops
* changed the `if` statements in the `then` part of the rule into conditions of the `when` side of the rule and hence created 2 different rules (NICS and RDM disk)
* removed the `setFocus()` since they have to be executed only once in `BasicFields` rule
* renamed `test` method in `test_NicsAndRdmDiskFlags` to indicate the test covers the case when we have both the flags (and updated the values to be consistent with the new rules)
* added test `test_NoFlags` to cover the case when a VM should have no flags

**TODO**
* implement `test_OnlyNicsFlag`, `test_OnlyRdmDiskFlag`, `test_NotEnoughNics` (`setNicsCount(2)`) and `test_RdmDiskFalse` tests (for each test check both flags, ie in `test_OnlyNicsFlag` test check flags set does not contain RDM Disk flag)
* refactor `VMWorkloadInventoryModel.diskSpace` to be a Long (not strictly related to this PR but needed to be consistent with some changes made in the `xavier-integration` application)
* refactor `VMWorkloadInventoryModel.memory` to be a Long (not strictly related to this PR but needed to be consistent with some changes made in the `xavier-integration` application)