### PR TITLE
MIGENG-138 Fixed Agenda Groups focusing order

### DIFF
--- a/src/main/java/org/jboss/xavier/analytics/functions/HelperFunctions.java
+++ b/src/main/java/org/jboss/xavier/analytics/functions/HelperFunctions.java
@@ -1,9 +1,55 @@
 package org.jboss.xavier.analytics.functions;
 
+import java.util.Arrays;
+
 public class HelperFunctions
 {
     public static int round(double value)
     {
         return (int) Math.round(value);
+    }
+
+    public static boolean isSupportedOS(String osToCheck)
+    {
+        return Arrays.stream(OSSupport.values()).anyMatch(value -> value.name().equalsIgnoreCase(osToCheck) && value.isSupported());
+    }
+
+    public static boolean isUnsupportedOS(String osToCheck)
+    {
+        return Arrays.stream(OSSupport.values()).anyMatch(value -> value.name().equalsIgnoreCase(osToCheck) && !value.isSupported());
+    }
+
+    public static boolean isUndetectedOS(String osToCheck)
+    {
+        return Arrays.stream(OSSupport.values()).noneMatch(value -> value.name().equalsIgnoreCase(osToCheck));
+    }
+
+    public enum OSSupport{
+        RHEL("RHEL", true),
+        SUSE("Suse", true),
+        WINDOWS("Windows",true),
+        ORACLE("Oracle Enterprise Linux",false),
+        CENTOS("CentOS",false),
+        DEBIAN("Debian",false),
+        UBUNTU("Ubuntu",false);
+
+        private final String name;
+        private final boolean isSupported;
+
+        OSSupport(String name, boolean isSupported)
+        {
+            this.name = name;
+            this.isSupported = isSupported;
+        }
+
+        boolean isSupported()
+        {
+            return this.isSupported;
+        }
+
+        public String getName()
+        {
+            return this.name;
+        }
     }
 }

--- a/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/inventory/WorkloadInventoryReportModel.java
+++ b/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/inventory/WorkloadInventoryReportModel.java
@@ -9,12 +9,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-import java.math.BigDecimal;
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Entity
 public class WorkloadInventoryReportModel
@@ -29,53 +27,6 @@ public class WorkloadInventoryReportModel
     public static final String COMPLEXITY_MEDIUM = "COMPLEXITY_MEDIUM";
     public static final String COMPLEXITY_HARD = "COMPLEXITY_HARD";
     public static final String COMPLEXITY_UNKNOWN = "COMPLEXITY_UNKNOWN";
-
-    public static enum OSSupport{
-        RHEL("RHEL", true),
-        SUSE("Suse", true),
-        WINDOWS("Windows",true),
-        ORACLE("Oracle Enterprise Linux",false),
-        CENTOS("CentOS",false),
-        DEBIAN("Debian",false),
-        UBUNTU("Ubuntu",false);
-
-
-        private final String name;
-        private final boolean isSupported;
-
-        OSSupport(String name, boolean isSupported)
-        {
-            this.name = name;
-            this.isSupported = isSupported;
-        }
-
-        boolean isSupported()
-        {
-            return this.isSupported;
-        }
-
-
-
-        public static boolean isSupportedOS(String osToCheck)
-        {
-            return Arrays.stream(OSSupport.values()).anyMatch(value -> value.name().equals(osToCheck) && value.isSupported());
-        }
-
-        public static boolean isUnsupportedOS(String osToCheck)
-        {
-            return Arrays.stream(OSSupport.values()).anyMatch(value -> value.name().equals(osToCheck) && !value.isSupported());
-        }
-
-        public static boolean isUndetectedOS(String osToCheck)
-        {
-            return Arrays.stream(OSSupport.values()).noneMatch(value -> value.name().equals(osToCheck));
-        }
-
-        public String getName()
-        {
-            return this.name;
-        }
-    }
 
     @Id
     @GeneratedValue(strategy = javax.persistence.GenerationType.AUTO, generator = "WORKLOADINVENTORYREPORTMODEL_ID_GENERATOR")

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/BasicFields.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/BasicFields.drl
@@ -33,8 +33,8 @@ rule "Copy basic fields and agenda controller"
         workloadInventoryReport.setOsName(vmWorkloadInventoryModel.getOsProductName());
 
         insert(workloadInventoryReport);
-        kcontext.getKieRuntime().getAgenda().getAgendaGroup("Flags").setFocus();
-        kcontext.getKieRuntime().getAgenda().getAgendaGroup("Targets").setFocus();
-        kcontext.getKieRuntime().getAgenda().getAgendaGroup("Complexity").setFocus();
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("Workloads").setFocus();
+        kcontext.getKieRuntime().getAgenda().getAgendaGroup("Complexity").setFocus();
+        kcontext.getKieRuntime().getAgenda().getAgendaGroup("Targets").setFocus();
+        kcontext.getKieRuntime().getAgenda().getAgendaGroup("Flags").setFocus();
 end

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Complexity.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Complexity.drl
@@ -4,16 +4,21 @@ import org.jboss.xavier.analytics.pojo.input.workload.inventory.VMWorkloadInvent
 import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel
 import java.util.HashSet;
 
+import function org.jboss.xavier.analytics.functions.HelperFunctions.isSupportedOS;
+import function org.jboss.xavier.analytics.functions.HelperFunctions.isUnsupportedOS;
+import function org.jboss.xavier.analytics.functions.HelperFunctions.isUndetectedOS;
+
 dialect "java"
 agenda-group "Complexity"
 lock-on-active true
+auto-focus false
 
 rule "No_Flag_Supported_OS"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
             flagsIMS == null,
             osName != null,
-            WorkloadInventoryReportModel.OSSupport.isSupportedOS(osName)
+            isSupportedOS(osName)
         )
     then
         modify(workloadInventoryReport)
@@ -28,7 +33,7 @@ rule "One_Flag_Supported_OS"
             flagsIMS != null,
             flagsIMS.size() == 1,
             osName != null,
-            WorkloadInventoryReportModel.OSSupport.isSupportedOS(osName)
+            isSupportedOS(osName)
         )
     then
         modify(workloadInventoryReport)
@@ -43,7 +48,7 @@ rule "More_Than_One_Flag_Supported_OS"
             flagsIMS != null,
             flagsIMS.size() > 1,
             osName != null,
-            WorkloadInventoryReportModel.OSSupport.isSupportedOS(osName)
+            isSupportedOS(osName)
         )
     then
         modify(workloadInventoryReport)
@@ -57,7 +62,7 @@ rule "No_Flags_Not_Supported_OS"
         workloadInventoryReport : WorkloadInventoryReportModel(
             flagsIMS == null,
             osName != null,
-            WorkloadInventoryReportModel.OSSupport.isUnsupportedOS(osName)
+            isUnsupportedOS(osName)
         )
     then
         modify(workloadInventoryReport)
@@ -72,7 +77,7 @@ rule "One_Or_More_Flags_Not_Supported_OS"
             flagsIMS != null,
             flagsIMS.size() >= 1,
             osName != null,
-            WorkloadInventoryReportModel.OSSupport.isUnsupportedOS(osName)
+            isUnsupportedOS(osName)
     )
     then
         modify(workloadInventoryReport)
@@ -85,7 +90,7 @@ rule "Not_Detected_OS"
     when
             workloadInventoryReport : WorkloadInventoryReportModel(
             osName != null,
-            WorkloadInventoryReportModel.OSSupport.isUndetectedOS(osName)
+            isUndetectedOS(osName)
     )
     then
         modify(workloadInventoryReport)

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Flags.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Flags.drl
@@ -7,6 +7,7 @@ import java.util.HashSet;
 dialect "java"
 agenda-group "Flags"
 lock-on-active true
+auto-focus false
 
 rule "Flag_Nics"
     when

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Workloads.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Workloads.drl
@@ -7,6 +7,7 @@ import java.util.HashSet;
 dialect "java"
 agenda-group "Workloads"
 lock-on-active true
+auto-focus false
 
 rule "Workloads_sample_systemServicesNames_rule"
     when
@@ -14,7 +15,7 @@ rule "Workloads_sample_systemServicesNames_rule"
             systemServicesNames != null,
             systemServicesNames.size() > 0
         )
-        //workloadInventoryReport : WorkloadInventoryReportModel()
+        workloadInventoryReport : WorkloadInventoryReportModel()
     then
         System.out.println(vmWorkloadInventoryModel.getVmName() + " has systemServicesNames: ");
         vmWorkloadInventoryModel.getSystemServicesNames().forEach(System.out::println);
@@ -26,7 +27,7 @@ rule "Workloads_sample_files_rule"
             files != null,
             files.size() > 0
         )
-        //workloadInventoryReport : WorkloadInventoryReportModel()
+        workloadInventoryReport : WorkloadInventoryReportModel()
     then
         System.out.println(vmWorkloadInventoryModel.getVmName() + " has files: ");
         vmWorkloadInventoryModel.getFiles().forEach((key, value) -> System.out.println(key));

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/ComplexityTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/ComplexityTest.java
@@ -1,17 +1,18 @@
 package org.jboss.xavier.analytics.rules.workload.inventory;
 
-import org.jboss.xavier.analytics.pojo.input.workload.inventory.VMWorkloadInventoryModel;
 import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
 import org.jboss.xavier.analytics.rules.BaseTest;
 import org.jboss.xavier.analytics.test.Utils;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.io.ResourceType;
 import org.kie.internal.command.CommandFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ComplexityTest extends BaseTest {

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
@@ -11,7 +11,6 @@ import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.QueryResultsRow;
 import org.kie.internal.command.CommandFactory;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -41,11 +40,12 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         vmWorkloadInventoryModel.setDatacenter("V2V-DC");
         vmWorkloadInventoryModel.setCluster("Cluster 1");
         vmWorkloadInventoryModel.setVmName("vm tests");
-        vmWorkloadInventoryModel.setDiskSpace(new Long(100000001));
-        vmWorkloadInventoryModel.setMemory(new Long(4096));
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
         vmWorkloadInventoryModel.setCpuCores(4);
         vmWorkloadInventoryModel.setGuestOSFullName("Red Hat Enterprise Linux Server release 7.6 (Maipo)");
-        vmWorkloadInventoryModel.setOsProductName("RHEL");
+        // keep it lower case to check that the rules evaluate it ignoring the case
+        vmWorkloadInventoryModel.setOsProductName("rhel");
 
         //Flags
         vmWorkloadInventoryModel.setNicsCount(5);
@@ -62,9 +62,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
 
         facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
 
-
-
-
         // define the list of commands you want to be executed by Drools
         List<Command> commands = new ArrayList<>();
         // first generate and add all of the facts created above
@@ -78,18 +75,18 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
        Utils.verifyRulesFiredNames(this.agendaEventListener,
             // BasicFields
-            "Copy basic fields and agenda controller", "No_Flag_Supported_OS",
+            "Copy basic fields and agenda controller",
             // Flags
-               "Flag_Nics", "One_Flag_Supported_OS", "Flag_Rdm_Disk", "More_Than_One_Flag_Supported_OS", "Flag_Shared_Disks",
+           "Flag_Nics", "Flag_Rdm_Disk", "Flag_Shared_Disks",
             // Target
             // Complexity
-
-               // Workloads
-               "Workloads_sample_systemServicesNames_rule", "Workloads_sample_files_rule"
+           "More_Than_One_Flag_Supported_OS",
+           // Workloads
+           "Workloads_sample_systemServicesNames_rule", "Workloads_sample_files_rule"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -109,11 +106,11 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("V2V-DC",workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals("Cluster 1",workloadInventoryReportModel.getCluster());
         Assert.assertEquals("vm tests",workloadInventoryReportModel.getVmName());
-        Assert.assertEquals(new Long(100000001).intValue(),workloadInventoryReportModel.getDiskSpace().intValue());
+        Assert.assertEquals(100000001L,workloadInventoryReportModel.getDiskSpace(), 0);
         Assert.assertEquals(4096,workloadInventoryReportModel.getMemory().intValue());
         Assert.assertEquals(4,workloadInventoryReportModel.getCpuCores().intValue());
         Assert.assertEquals("Red Hat Enterprise Linux Server release 7.6 (Maipo)",workloadInventoryReportModel.getOsDescription());
-        Assert.assertEquals("RHEL",workloadInventoryReportModel.getOsName());
+        Assert.assertEquals("rhel",workloadInventoryReportModel.getOsName());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);


### PR DESCRIPTION
- changed the Agenda Group focusing order because (and i'm not able to find any doc about this) the focus ordering is a stack so the last pushed will be the first to pop out
- changed the WI integration test to have the right checks for rules fired (7 and not 9) and their order
- added `auto-focus false` to prevent any rules that matches to give focus to its agenda group
- moved the `Enum` (which is really a nice idea :+1: ) to be in the `HelperFunctions` together with the boolean methods to check the OS (i made the check to ignore the case so that we avoid issues like having `rhel` instead of `RHEL`) so that we can keep the `WorkloadInventoryReportModel` clean and changed the `Complexity` to use the functions