### PR TITLE
MIGENG-349 improved fileNameAndContentsContainSpecifiedStrings to work with entries set

### DIFF
--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Workloads.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Workloads.drl
@@ -2,7 +2,6 @@ package org.jboss.xavier.analytics.rules.workload.inventory;
 
 import org.jboss.xavier.analytics.pojo.input.workload.inventory.VMWorkloadInventoryModel
 import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel
-import java.util.HashSet;
 
 dialect "java"
 agenda-group "Workloads"
@@ -29,12 +28,13 @@ function boolean filesContentsContainsString(VMWorkloadInventoryModel vmWorkload
     return vmWorkloadInventoryModel.getFiles().values().stream().anyMatch(value -> value != null && value.toLowerCase().contains(searchTerm.toLowerCase()));
 }
 
-
 function boolean fileNameAndContentsContainSpecifiedStrings(VMWorkloadInventoryModel vmWorkloadInventoryModel, String nameSearchTerm, String contentsSearchTerm)
 {
-    return vmWorkloadInventoryModel.getFiles().keySet().stream().anyMatch(value -> value.toLowerCase().contains(nameSearchTerm.toLowerCase()) &&
-                                            vmWorkloadInventoryModel.getFiles().get(value) != null &&
-                                            vmWorkloadInventoryModel.getFiles().get(value).toLowerCase().contains(contentsSearchTerm.toLowerCase()));
+    return vmWorkloadInventoryModel.getFiles().entrySet().stream().anyMatch(entry ->
+        entry.getKey().toLowerCase().contains(nameSearchTerm.toLowerCase()) &&
+        entry.getValue() != null &&
+        entry.getValue().toLowerCase().contains(contentsSearchTerm.toLowerCase())
+    );
 }
 
 rule "Workloads_Tomcat"

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
@@ -3469,6 +3469,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         vmWorkloadInventoryModel.setSystemServicesNames(systemServicesNames);
 
         Map<String, String> files = new HashMap<>();
+        files.put("/etc/foo", null);
         files.put("/etc/group", "ccmservice");
         vmWorkloadInventoryModel.setFiles(files);
         facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);


### PR DESCRIPTION
This applies to https://github.com/project-xavier/xavier-analytics/pull/49
- refactored the `fileNameAndContentsContainSpecifiedStrings` method to work with entries set
- changed test case to cover the `null` content file case