### PR TITLE
MIGENG-427 Added 'Target_CNV_Reevaluate' rule

### DIFF
--- a/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/inventory/WorkloadInventoryReportModel.java
+++ b/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/inventory/WorkloadInventoryReportModel.java
@@ -9,7 +9,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -34,6 +33,8 @@ public class WorkloadInventoryReportModel
     public static final String DATACENTER_DEFAULT_VALUE = "No datacenter defined";
     public static final String CLUSTER_DEFAULT_VALUE = "No cluster defined";
     public static final String HOST_NAME_DEFAULT_VALUE = "No host defined";
+
+    public static final String TARGET_CNV = "CNV";
 
     @Id
     @GeneratedValue(strategy = javax.persistence.GenerationType.AUTO, generator = "WORKLOADINVENTORYREPORTMODEL_ID_GENERATOR")

--- a/src/main/resources/META-INF/kmodule.xml
+++ b/src/main/resources/META-INF/kmodule.xml
@@ -14,7 +14,7 @@
   <kbase name="WorkloadSummaryKBase" default="false" eventProcessingMode="stream" equalsBehavior="identity" packages="org.jboss.xavier.analytics.rules.workload.summary">
     <ksession name="WorkloadSummaryKSession0" type="stateless" default="true" clockType="realtime"/>
   </kbase>
-  <kbase name="WorkloadInventoryComplexityKBase" default="false" eventProcessingMode="stream" equalsBehavior="identity" packages="org.jboss.xavier.analytics.rules.agendafocus.complexity, org.jboss.xavier.analytics.rules.workload.inventory.complexity, org.jboss.xavier.analytics.rules.workload.inventory.queries">
-    <ksession name="WorkloadInventoryComplexityKSession0" type="stateless" default="true" clockType="realtime"/>
+  <kbase name="WorkloadInventoryReevaluateKBase" default="false" eventProcessingMode="stream" equalsBehavior="identity" packages="org.jboss.xavier.analytics.rules.agendafocus.reevaluate, org.jboss.xavier.analytics.rules.workload.inventory.complexity, org.jboss.xavier.analytics.rules.workload.inventory.targets, org.jboss.xavier.analytics.rules.workload.inventory.queries">
+    <ksession name="WorkloadInventoryReevaluateKSession0" type="stateless" default="true" clockType="realtime"/>
   </kbase>
 </kmodule>

--- a/src/main/resources/org/jboss/xavier/analytics/rules/agendafocus/reevaluate/AgendaFocusForReevaluate.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/agendafocus/reevaluate/AgendaFocusForReevaluate.drl
@@ -1,13 +1,14 @@
-package org.jboss.xavier.analytics.rules.agendafocus.complexity;
+package org.jboss.xavier.analytics.rules.agendafocus.reevaluate;
+
 import java.lang.String;
 import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel
-dialect "java"
 
+dialect "java"
 agenda-group "MAIN"
 
-rule "AgendaFocusForComplexity"
+rule "AgendaFocusForReevaluate"
     when
-        workloadInventoryReport : WorkloadInventoryReportModel()
     then
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("Complexity").setFocus();
+        kcontext.getKieRuntime().getAgenda().getAgendaGroup("TargetsReevaluate").setFocus();
 end

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Targets.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/Targets.drl
@@ -79,7 +79,7 @@ rule "Target_CNV"
     then
         modify(workloadInventoryReport)
         {
-            addRecommendedTargetsIMS("CNV")
+            addRecommendedTargetsIMS(WorkloadInventoryReportModel.TARGET_CNV)
         }
 end
 

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/targets/TargetsReevaluate.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/targets/TargetsReevaluate.drl
@@ -1,0 +1,23 @@
+package org.jboss.xavier.analytics.rules.workload.inventory.targets;
+
+import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
+
+dialect "java"
+agenda-group "TargetsReevaluate"
+lock-on-active true
+auto-focus false
+
+rule "Target_CNV_Reevaluate"
+    when
+        workloadInventoryReport : WorkloadInventoryReportModel(
+            getRecommendedTargetsIMS() != null,
+            getRecommendedTargetsIMS().contains(WorkloadInventoryReportModel.TARGET_CNV),
+            getFlagsIMS() != null,
+            getFlagsIMS().contains(WorkloadInventoryReportModel.SHARED_DISK_FLAG_NAME)
+        )
+    then
+        modify(workloadInventoryReport)
+        {
+            getRecommendedTargetsIMS().remove(WorkloadInventoryReportModel.TARGET_CNV)
+        }
+end

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/TargetsTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/TargetsTest.java
@@ -133,7 +133,7 @@ public class TargetsTest extends BaseTest {
         Assert.assertTrue(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("None".toLowerCase())));
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("OSP".toLowerCase())));
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHV".toLowerCase())));
-        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("Convert2RHEL".toLowerCase())));
+        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHEL".toLowerCase())));
 
     }
 
@@ -218,7 +218,7 @@ public class TargetsTest extends BaseTest {
         Assert.assertEquals(1, report.getRecommendedTargetsIMS().size());
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHV".toLowerCase())));
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("OSP".toLowerCase())));
-        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("Convert2RHEL".toLowerCase())));
+        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHEL".toLowerCase())));
         Assert.assertTrue(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("None".toLowerCase())));
     }
 
@@ -247,7 +247,7 @@ public class TargetsTest extends BaseTest {
         Assert.assertEquals(1, report.getRecommendedTargetsIMS().size());
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHV".toLowerCase())));
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("OSP".toLowerCase())));
-        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("Convert2RHEL".toLowerCase())));
+        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHEL".toLowerCase())));
         Assert.assertTrue(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("None".toLowerCase())));
     }
 
@@ -276,7 +276,7 @@ public class TargetsTest extends BaseTest {
         Assert.assertEquals(1, report.getRecommendedTargetsIMS().size());
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHV".toLowerCase())));
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("OSP".toLowerCase())));
-        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("Convert2RHEL".toLowerCase())));
+        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHEL".toLowerCase())));
         Assert.assertTrue(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("None".toLowerCase())));
     }
 
@@ -305,7 +305,7 @@ public class TargetsTest extends BaseTest {
         Assert.assertEquals(1, report.getRecommendedTargetsIMS().size());
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHV".toLowerCase())));
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("OSP".toLowerCase())));
-        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("Convert2RHEL".toLowerCase())));
+        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHEL".toLowerCase())));
         Assert.assertTrue(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("None".toLowerCase())));
     }
 
@@ -334,7 +334,7 @@ public class TargetsTest extends BaseTest {
         Assert.assertEquals(2, report.getRecommendedTargetsIMS().size());
         Assert.assertTrue(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHV".toLowerCase())));
         Assert.assertTrue(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("OSP".toLowerCase())));
-        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("Convert2RHEL".toLowerCase())));
+        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHEL".toLowerCase())));
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("None".toLowerCase())));
     }
 
@@ -363,7 +363,7 @@ public class TargetsTest extends BaseTest {
         Assert.assertEquals(1, report.getRecommendedTargetsIMS().size());
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHV".toLowerCase())));
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("OSP".toLowerCase())));
-        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("Convert2RHEL".toLowerCase())));
+        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHEL".toLowerCase())));
         Assert.assertTrue(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("None".toLowerCase())));
     }
 
@@ -392,7 +392,7 @@ public class TargetsTest extends BaseTest {
         Assert.assertEquals(1, report.getRecommendedTargetsIMS().size());
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHV".toLowerCase())));
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("OSP".toLowerCase())));
-        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("Convert2RHEL".toLowerCase())));
+        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHEL".toLowerCase())));
         Assert.assertTrue(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("None".toLowerCase())));
     }
 
@@ -421,7 +421,7 @@ public class TargetsTest extends BaseTest {
         Assert.assertEquals(1, report.getRecommendedTargetsIMS().size());
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHV".toLowerCase())));
         Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("OSP".toLowerCase())));
-        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("Convert2RHEL".toLowerCase())));
+        Assert.assertFalse(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("RHEL".toLowerCase())));
         Assert.assertTrue(report.getRecommendedTargetsIMS().stream().anyMatch(target -> target.toLowerCase().contains("None".toLowerCase())));
     }
 

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
@@ -25,7 +25,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
 
     public WorkloadInventoryReportTest()
     {
-        super("WorkloadInventoryKSession0", "org.jboss.xavier.analytics.rules.workload.inventory.*", 39);
+        super("WorkloadInventoryKSession0", "org.jboss.xavier.analytics.rules.workload.inventory.*", 40);
     }
 
     @Test

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/complexity/ComplexityTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/complexity/ComplexityTest.java
@@ -1,4 +1,4 @@
-package org.jboss.xavier.analytics.rules.workload.inventory;
+package org.jboss.xavier.analytics.rules.workload.inventory.complexity;
 
 import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
 import org.jboss.xavier.analytics.rules.BaseTest;

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/targets/TargetsReevaluateTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/targets/TargetsReevaluateTest.java
@@ -1,0 +1,136 @@
+package org.jboss.xavier.analytics.rules.workload.inventory.targets;
+
+import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
+import org.jboss.xavier.analytics.rules.BaseTest;
+import org.jboss.xavier.analytics.test.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kie.api.io.ResourceType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TargetsReevaluateTest extends BaseTest {
+
+    public TargetsReevaluateTest() {
+        super("/org/jboss/xavier/analytics/rules/workload/inventory/targets/TargetsReevaluate.drl", ResourceType.DRL,
+                "org.jboss.xavier.analytics.rules.workload.inventory.targets", 1);
+    }
+
+    @Test
+    public void testFlagSharedDiskAndTargetCNV() {
+        Map<String, Object> facts = new HashMap<>();
+        // always add a String fact with the name of the agenda group defined in the DRL file (e.g. "SourceCosts")
+        facts.put("agendaGroup", "TargetsReevaluate");
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+        workloadInventoryReportModel.setOsDescription("Red Hat Enterprise Linux v7.6");
+        workloadInventoryReportModel.addFlagIMS(WorkloadInventoryReportModel.SHARED_DISK_FLAG_NAME);
+        workloadInventoryReportModel.addRecommendedTargetsIMS(WorkloadInventoryReportModel.TARGET_CNV);
+
+        facts.put("workloadInventoryReportModel",workloadInventoryReportModel);
+
+        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
+
+        Assert.assertEquals(2, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Utils.verifyRulesFiredNames(this.agendaEventListener, "AgendaFocusForTest", "Target_CNV_Reevaluate");
+
+        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
+
+        // just one report has to be created
+        Assert.assertEquals(1, reports.size());
+        WorkloadInventoryReportModel report = reports.get(0);
+        Assert.assertNotNull(report.getRecommendedTargetsIMS());
+        Assert.assertEquals(0, report.getRecommendedTargetsIMS().size());
+    }
+
+    @Test
+    public void testFlagSharedDiskAndNoTargetCNV() {
+        Map<String, Object> facts = new HashMap<>();
+        // always add a String fact with the name of the agenda group defined in the DRL file (e.g. "SourceCosts")
+        facts.put("agendaGroup", "TargetsReevaluate");
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+        workloadInventoryReportModel.setOsDescription("CentOS");
+        workloadInventoryReportModel.addFlagIMS(WorkloadInventoryReportModel.RDM_DISK_FLAG_NAME);
+        workloadInventoryReportModel.addFlagIMS(WorkloadInventoryReportModel.SHARED_DISK_FLAG_NAME);
+        workloadInventoryReportModel.addRecommendedTargetsIMS("RHV");
+
+        facts.put("workloadInventoryReportModel",workloadInventoryReportModel);
+
+        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
+
+        Assert.assertEquals(1, results.get(NUMBER_OF_FIRED_RULE_KEY));
+
+        Utils.verifyRulesFiredNames(this.agendaEventListener, "AgendaFocusForTest");
+
+
+        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
+
+        // just one report has to be created
+        Assert.assertEquals(1, reports.size());
+        WorkloadInventoryReportModel report = reports.get(0);
+        Assert.assertNotNull(report.getRecommendedTargetsIMS());
+        Assert.assertEquals(1, report.getRecommendedTargetsIMS().size());
+        Assert.assertTrue(report.getRecommendedTargetsIMS().contains("RHV"));
+    }
+
+    @Test
+    public void testNoFlagSharedDiskAndTargetCNV() {
+        Map<String, Object> facts = new HashMap<>();
+        // always add a String fact with the name of the agenda group defined in the DRL file (e.g. "SourceCosts")
+        facts.put("agendaGroup", "TargetsReevaluate");
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+        workloadInventoryReportModel.setOsDescription("Red Hat Enterprise Linux v7.6");
+        workloadInventoryReportModel.addRecommendedTargetsIMS(WorkloadInventoryReportModel.TARGET_CNV);
+
+        facts.put("workloadInventoryReportModel",workloadInventoryReportModel);
+
+        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
+
+        Assert.assertEquals(1, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Utils.verifyRulesFiredNames(this.agendaEventListener, "AgendaFocusForTest");
+
+        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
+
+        // just one report has to be created
+        Assert.assertEquals(1, reports.size());
+        WorkloadInventoryReportModel report = reports.get(0);
+        Assert.assertNotNull(report.getRecommendedTargetsIMS());
+        Assert.assertEquals(1, report.getRecommendedTargetsIMS().size());
+        Assert.assertTrue(report.getRecommendedTargetsIMS().contains(WorkloadInventoryReportModel.TARGET_CNV));
+    }
+
+    @Test
+    public void testNoFlagSharedDiskAndNoTargetCNV() {
+        Map<String, Object> facts = new HashMap<>();
+        // always add a String fact with the name of the agenda group defined in the DRL file (e.g. "SourceCosts")
+        facts.put("agendaGroup", "TargetsReevaluate");
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+        workloadInventoryReportModel.setOsDescription("Ubuntu");
+        workloadInventoryReportModel.addRecommendedTargetsIMS("None");
+        workloadInventoryReportModel.addFlagIMS(WorkloadInventoryReportModel.MORE_THAN_4_NICS_FLAG_NAME);
+
+        facts.put("workloadInventoryReportModel",workloadInventoryReportModel);
+
+        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
+
+        Assert.assertEquals(1, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Utils.verifyRulesFiredNames(this.agendaEventListener, "AgendaFocusForTest");
+
+
+        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
+
+        // just one report has to be created
+        Assert.assertEquals(1, reports.size());
+        WorkloadInventoryReportModel report = reports.get(0);
+        Assert.assertNotNull(report.getRecommendedTargetsIMS());
+        Assert.assertEquals(1, report.getRecommendedTargetsIMS().size());
+        Assert.assertTrue(report.getRecommendedTargetsIMS().contains("None"));
+    }
+
+}


### PR DESCRIPTION
This applies to https://github.com/project-xavier/xavier-analytics/pull/55
- added `Target_CNV_Reevaluate` in order to reevaluate those VMs that were evaluated suitable for "CNV" target and then got added the "Shared Disk" flag in the `xavier-integration` application that makes them **UN**suitable for "CNV" target (with `TargetsReevaluateTest` test)
- added `WorkloadInventoryReportModel.TARGET_CNV` since it's now used in multiple places
- changed `WorkloadInventoryComplexityKSession0` to become `WorkloadInventoryReevaluateKSession0` to deal with rules for different areas/topics
- changed `AgendaFocusForComplexity` to become `AgendaFocusForReevaluate` to deal with rules for different areas/topics
- changed `WorkloadInventoryComplexityTest` to become `WorkloadInventoryReevaluateTest` to deal with rules for different areas/topics
- moved `ComplexityTest` into `complexity` folder to keep the test's package consistent with the rules it refers to
- fixed tests still checking for `Convert2RHEL` instead of `RHEL`